### PR TITLE
Fixed mechanize version to 0.2.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,8 @@ setup(
     ],
     scripts = ['redactedbetter'],
     install_requires = [
-        'mutagen',
-        'mechanize',
-        'requests'
+        'mutagen>=1.20',
+        'mechanize==0.2.5',
+        'requests>=1.0'
     ]
 )


### PR DESCRIPTION
I'm making use of `python setup.py install` for a docker image I'm creating and it's useful to have `redactedbetter` available in the PATH