### PR TITLE
added piece_length to config

### DIFF
--- a/redactedbetter
+++ b/redactedbetter
@@ -83,6 +83,7 @@ def main():
         config.set('redacted', 'formats', 'flac, v0, 320')
         config.set('redacted', 'media', ', '.join(redactedapi.lossless_media))
         config.set('redacted', '24bit_behaviour','0')
+        config.set('redacted', 'piece_length', '18')
         config.write(open(args.config, 'w'))
         print 'Please edit the configuration file: %s' % args.config
         sys.exit(2)
@@ -208,7 +209,7 @@ def main():
                 tmpdir = tempfile.mkdtemp()
                 try:
                     transcode_dir = transcode.transcode_release(flac_dir, output_dir, format, max_threads=args.threads)
-                    new_torrent = transcode.make_torrent(transcode_dir, tmpdir, api.tracker, api.passkey)
+                    new_torrent = transcode.make_torrent(transcode_dir, tmpdir, api.tracker, api.passkey, config.get('redacted', 'piece_length'))
                     if upload_torrent:
                         permalink = api.permalink(torrent)
                         description = create_description(torrent, flac_dir, format, permalink)

--- a/transcode.py
+++ b/transcode.py
@@ -29,7 +29,7 @@ class TranscodeDownmixException(TranscodeException):
 
 class UnknownSampleRateException(TranscodeException):
     pass
-    
+
 # In most Unix shells, pipelines only report the return code of the
 # last process. We need to know if any process in the transcode
 # pipeline fails, not just the last one.
@@ -337,7 +337,7 @@ def transcode_release(flac_dir, output_dir, output_format, max_threads=None):
         shutil.rmtree(transcode_dir)
         raise
 
-def make_torrent(input_dir, output_dir, tracker, passkey):
+def make_torrent(input_dir, output_dir, tracker, passkey, piece_length):
     torrent = os.path.join(output_dir, os.path.basename(input_dir)) + ".torrent"
     if not os.path.exists(os.path.dirname(torrent)):
         os.path.makedirs(os.path.dirname(torrent))
@@ -345,7 +345,7 @@ def make_torrent(input_dir, output_dir, tracker, passkey):
         'tracker' : tracker,
         'passkey' : passkey,
     }
-    command = ["mktorrent", "-s", "RED", "-p", "-a", tracker_url, "-o", torrent, input_dir]
+    command = ["mktorrent", "-s", "RED", "-p", "-a", tracker_url, "-o", torrent, "-l", piece_length, input_dir]
     subprocess.check_output(command, stderr=subprocess.STDOUT)
     return torrent
 


### PR DESCRIPTION
If you create torrents for multiple sites using mktorrent, you have to have different piece lengths per tracker or else client's won't let you add that torrent twice (even with different trackers). This allows you to configure the piece length when creating torrent files.