### PR TITLE
Add ability to specify a session_cookie in the config file

### DIFF
--- a/redactedbetter
+++ b/redactedbetter
@@ -67,7 +67,7 @@ def main():
 
     args = parser.parse_args()
 
-    config = ConfigParser.SafeConfigParser()
+    config = ConfigParser.RawConfigParser()
     try:
         open(args.config)
         config.read(args.config)
@@ -77,6 +77,7 @@ def main():
         config.add_section('redacted')
         config.set('redacted', 'username', '')
         config.set('redacted', 'password', '')
+        config.set('redacted', 'session_cookie', '')
         config.set('redacted', 'data_dir', '')
         config.set('redacted', 'output_dir', '')
         config.set('redacted', 'torrent_dir', '')
@@ -90,6 +91,10 @@ def main():
     finally:
         username = config.get('redacted', 'username')
         password = config.get('redacted', 'password')
+        try:
+            session_cookie = os.path.expanduser(config.get('redacted', 'session_cookie'))
+        except ConfigParser.NoOptionError:
+            session_cookie = None
         do_24_bit = config.get('redacted', '24bit_behaviour')
         data_dir = os.path.expanduser(config.get('redacted', 'data_dir'))
         try:
@@ -117,7 +122,7 @@ def main():
     upload_torrent = not args.no_upload
 
     print 'Logging in to RED...'
-    api = redactedapi.RedactedAPI(username, password)
+    api = redactedapi.RedactedAPI(username, password, session_cookie)
 
     try:
         seen = pickle.load(open(args.cache))


### PR DESCRIPTION
This is a hack^H^H^H^Hsimplistic fix to enable a "logging in" via a currently valid session_cookie instead of a username/password combination.  In particular, if you have 2fa enabled (as you know you should), then the redactedapi.py can no longer log you in.

How to use: using developer tools, pull your current session_cookie from your browser.  Put that into the config file.

NOTE: This does not capture a cookie from the login/password, however.  I have enabled 2fa, so therefore the old method won't work (therefore I couldn't implement it). If someone else wanted to add that, I would expect it shouldn't be terribly difficult I presume.
